### PR TITLE
comment typo corrected

### DIFF
--- a/src/Adafruit_GPS.h
+++ b/src/Adafruit_GPS.h
@@ -195,7 +195,7 @@ public:
   char mag = 'X';    ///< Magnetic variation direction
   bool fix;          ///< Have a fix?
   uint8_t fixquality;    ///< Fix quality (0, 1, 2 = Invalid, GPS, DGPS)
-  uint8_t fixquality_3d; ///< 3D fix quality (1, 3, 3 = Nofix, 2D fix, 3D fix)
+  uint8_t fixquality_3d; ///< 3D fix quality (1, 2, 3 = Nofix, 2D fix, 3D fix)
   uint8_t satellites;    ///< Number of satellites in use
 
   uint16_t LOCUS_serial;  ///< Log serial number


### PR DESCRIPTION
Typo in the comment for fixquality_3d
Checked against documentation on the internet that a 2d FIX has indeed the number 2 in the GPGSA sentence